### PR TITLE
Fixing location of "in," keyword for 08_phong

### DIFF
--- a/08_phong/test_vs.glsl
+++ b/08_phong/test_vs.glsl
@@ -1,7 +1,7 @@
 #version 400
 
-in layout (location = 0) vec3 vertex_position;
-in layout (location = 1) vec3 vertex_normal;
+layout (location = 0) in vec3 vertex_position;
+layout (location = 1) in vec3 vertex_normal;
 uniform mat4 projection_mat, view_mat, model_mat;
 out vec3 position_eye, normal_eye;
 


### PR DESCRIPTION
Would provide the error upon shader compilation:

```
ERROR: GL shader index 1 did not compile
shader info log for GL index 1:
0:3(43): error: global variable cannot be given an explicit location in vertex
shader
0:4(41): error: global variable cannot be given an explicit location in vertex 
shader
```

For the vertex shader.  Moving the "in," keyword fixes this issue.
