### PR TITLE
fix for retina displays

### DIFF
--- a/01_extended_init/main.c
+++ b/01_extended_init/main.c
@@ -87,8 +87,8 @@ void glfw_error_callback( int error, const char *description ) {
 int g_gl_width = 640;
 int g_gl_height = 480;
 
-/* we will tell GLFW to run this function whenever the window is resized */
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+/* we will tell GLFW to run this function whenever the framebuffer size is changed */
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );
@@ -220,7 +220,8 @@ int main() {
 		glfwTerminate();
 		return 1;
 	}
-	glfwSetWindowSizeCallback( window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback(window, glfw_framebuffer_size_callback);
+	//
 	glfwMakeContextCurrent( window );
 
 	// start GLEW extension handler

--- a/02_shaders/gl_utils.c
+++ b/02_shaders/gl_utils.c
@@ -107,7 +107,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -134,7 +134,7 @@ void glfw_error_callback( int error, const char *description ) {
 }
 
 /* a call-back function */
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/02_shaders/gl_utils.h
+++ b/02_shaders/gl_utils.h
@@ -39,6 +39,6 @@ void log_gl_params();
 
 void _update_fps_counter( GLFWwindow *window );
 
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 
 #endif

--- a/03_vertex_buffer_objects/gl_utils.cpp
+++ b/03_vertex_buffer_objects/gl_utils.cpp
@@ -101,7 +101,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -125,7 +125,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/03_vertex_buffer_objects/gl_utils.h
+++ b/03_vertex_buffer_objects/gl_utils.h
@@ -36,7 +36,7 @@ void _update_fps_counter( GLFWwindow *window );
 
 const char *GL_type_to_string( unsigned int type );
 
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 
 void print_shader_info_log( GLuint shader_index );
 

--- a/04_mats_and_vecs/gl_utils.cpp
+++ b/04_mats_and_vecs/gl_utils.cpp
@@ -101,7 +101,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -125,7 +125,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/04_mats_and_vecs/gl_utils.h
+++ b/04_mats_and_vecs/gl_utils.h
@@ -32,7 +32,7 @@ bool gl_log_err( const char *message, ... );
 void glfw_error_callback( int error, const char *description );
 
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 
 void log_gl_params();
 

--- a/05_virtual_camera/gl_utils.cpp
+++ b/05_virtual_camera/gl_utils.cpp
@@ -101,7 +101,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -125,7 +125,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/05_virtual_camera/gl_utils.h
+++ b/05_virtual_camera/gl_utils.h
@@ -32,7 +32,7 @@ bool gl_log_err( const char *message, ... );
 void glfw_error_callback( int error, const char *description );
 
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 
 void log_gl_params();
 

--- a/06_vcam_with_quaternion/gl_utils.cpp
+++ b/06_vcam_with_quaternion/gl_utils.cpp
@@ -104,7 +104,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -128,7 +128,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/06_vcam_with_quaternion/gl_utils.h
+++ b/06_vcam_with_quaternion/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/07_ray_picking/gl_utils.cpp
+++ b/07_ray_picking/gl_utils.cpp
@@ -104,7 +104,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -128,7 +128,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/07_ray_picking/gl_utils.h
+++ b/07_ray_picking/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/08_phong/gl_utils.cpp
+++ b/08_phong/gl_utils.cpp
@@ -101,7 +101,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -125,7 +125,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/08_phong/gl_utils.h
+++ b/08_phong/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/09_texture_mapping/gl_utils.cpp
+++ b/09_texture_mapping/gl_utils.cpp
@@ -101,7 +101,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -125,7 +125,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/09_texture_mapping/gl_utils.h
+++ b/09_texture_mapping/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/10_screen_capture/gl_utils.cpp
+++ b/10_screen_capture/gl_utils.cpp
@@ -101,7 +101,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -125,7 +125,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/10_screen_capture/gl_utils.h
+++ b/10_screen_capture/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/11_video_capture/gl_utils.cpp
+++ b/11_video_capture/gl_utils.cpp
@@ -101,7 +101,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -125,7 +125,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/11_video_capture/gl_utils.h
+++ b/11_video_capture/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/12_debugging_shaders/gl_utils.cpp
+++ b/12_debugging_shaders/gl_utils.cpp
@@ -101,7 +101,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -125,7 +125,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/12_debugging_shaders/gl_utils.h
+++ b/12_debugging_shaders/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/13_mesh_import/gl_utils.cpp
+++ b/13_mesh_import/gl_utils.cpp
@@ -101,7 +101,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -125,7 +125,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/13_mesh_import/gl_utils.h
+++ b/13_mesh_import/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/14_multi_tex/gl_utils.cpp
+++ b/14_multi_tex/gl_utils.cpp
@@ -101,7 +101,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -125,7 +125,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/14_multi_tex/gl_utils.h
+++ b/14_multi_tex/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/15_phongtextures/gl_utils.cpp
+++ b/15_phongtextures/gl_utils.cpp
@@ -101,7 +101,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -125,7 +125,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/15_phongtextures/gl_utils.h
+++ b/15_phongtextures/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/16_frag_reject/gl_utils.cpp
+++ b/16_frag_reject/gl_utils.cpp
@@ -101,7 +101,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -125,7 +125,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/16_frag_reject/gl_utils.h
+++ b/16_frag_reject/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/17_alpha_blending/gl_utils.cpp
+++ b/17_alpha_blending/gl_utils.cpp
@@ -101,7 +101,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -125,7 +125,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/17_alpha_blending/gl_utils.h
+++ b/17_alpha_blending/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framerbuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/18_spotlights/gl_utils.cpp
+++ b/18_spotlights/gl_utils.cpp
@@ -101,7 +101,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -125,7 +125,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/18_spotlights/gl_utils.h
+++ b/18_spotlights/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/19_fog/gl_utils.cpp
+++ b/19_fog/gl_utils.cpp
@@ -101,7 +101,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -125,7 +125,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/19_fog/gl_utils.h
+++ b/19_fog/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/20_normal_mapping/gl_utils.cpp
+++ b/20_normal_mapping/gl_utils.cpp
@@ -103,7 +103,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -127,7 +127,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/20_normal_mapping/gl_utils.h
+++ b/20_normal_mapping/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/21_cube_mapping/gl_utils.cpp
+++ b/21_cube_mapping/gl_utils.cpp
@@ -103,7 +103,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -127,7 +127,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/21_cube_mapping/gl_utils.h
+++ b/21_cube_mapping/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/22_geom_shaders/gl_utils.cpp
+++ b/22_geom_shaders/gl_utils.cpp
@@ -101,7 +101,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -125,7 +125,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/22_geom_shaders/gl_utils.h
+++ b/22_geom_shaders/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/23_tessellation_shaders/gl_utils.cpp
+++ b/23_tessellation_shaders/gl_utils.cpp
@@ -58,7 +58,7 @@ void glfw_error_callback( int error, const char *description ) {
 }
 
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/23_tessellation_shaders/gl_utils.h
+++ b/23_tessellation_shaders/gl_utils.h
@@ -21,7 +21,7 @@ bool gl_log_err( const char *message, ... );
 void glfw_error_callback( int error, const char *description );
 
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 
 void log_gl_params();
 

--- a/23_tessellation_shaders/main.cpp
+++ b/23_tessellation_shaders/main.cpp
@@ -60,7 +60,7 @@ int main() {
 		glfwTerminate();
 		return 1;
 	}
-	glfwSetWindowSizeCallback( window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );

--- a/24_gui_panels/main.cpp
+++ b/24_gui_panels/main.cpp
@@ -153,7 +153,7 @@ bool load_texture( const char *file_name, GLuint *tex ) {
 }
 
 /* we will tell GLFW to run this function whenever the window is resized */
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_viewport_width = width;
 	g_viewport_height = height;
 	/* update any perspective matrices used here */
@@ -176,7 +176,7 @@ int main() {
 #endif
 	GLFWwindow *window = glfwCreateWindow( g_viewport_width, g_viewport_height,
 																				 "GUI Panels", NULL, NULL );
-	glfwSetWindowSizeCallback( window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( window );
 	glewExperimental = GL_TRUE;
 	glewInit();

--- a/25_sprite_sheets/main.cpp
+++ b/25_sprite_sheets/main.cpp
@@ -133,9 +133,10 @@ bool load_texture( const char *file_name, GLuint *tex ) {
 }
 
 /* we will tell GLFW to run this function whenever the window is resized */
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_viewport_width = width;
 	g_viewport_height = height;
+
 	/* update any perspective matrices used here */
 	P = perspective( 67.0f, (float)g_viewport_width / (float)g_viewport_height, 0.1f,
 									 100.0f );
@@ -157,7 +158,7 @@ int main() {
 
 	GLFWwindow *window = glfwCreateWindow( g_viewport_width, g_viewport_height,
 																				 "Sprite Sheets", NULL, NULL );
-	glfwSetWindowSizeCallback( window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( window );
 	glewExperimental = GL_TRUE;
 	glewInit();

--- a/26_bitmap_fonts/main.cpp
+++ b/26_bitmap_fonts/main.cpp
@@ -278,7 +278,7 @@ bool load_texture( const char *file_name, GLuint *tex ) {
 }
 
 /* we will tell GLFW to run this function whenever the window is resized */
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_viewport_width = width;
 	g_viewport_height = height;
 	/* update any perspective matrices used here */
@@ -298,7 +298,7 @@ int main() {
 #endif
 	GLFWwindow *window = glfwCreateWindow( g_viewport_width, g_viewport_height,
 																				 "Bitmap Fonts", NULL, NULL );
-	glfwSetWindowSizeCallback( window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( window );
 	glewExperimental = GL_TRUE;
 	glewInit();

--- a/27_font_atlas/viewer_main.cpp
+++ b/27_font_atlas/viewer_main.cpp
@@ -227,7 +227,7 @@ bool load_texture( const char *file_name, GLuint *tex ) {
 }
 
 /* we will tell GLFW to run this function whenever the window is resized */
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_viewport_width = width;
 	g_viewport_height = height;
 	/* update any perspective matrices used here */
@@ -248,7 +248,7 @@ int main() {
 
 	GLFWwindow *window = glfwCreateWindow( g_viewport_width, g_viewport_height,
 																				 "Bitmap Fonts", NULL, NULL );
-	glfwSetWindowSizeCallback( window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( window );
 	glewExperimental = GL_TRUE;
 	glewInit();

--- a/28_uniform_buffer_object/gl_utils.cpp
+++ b/28_uniform_buffer_object/gl_utils.cpp
@@ -104,7 +104,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	// start GLEW extension handler
@@ -126,7 +126,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/28_uniform_buffer_object/gl_utils.h
+++ b/28_uniform_buffer_object/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/29_particle_systems/gl_utils.cpp
+++ b/29_particle_systems/gl_utils.cpp
@@ -108,7 +108,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -132,7 +132,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/29_particle_systems/gl_utils.h
+++ b/29_particle_systems/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/30_skinning_part_one/gl_utils.cpp
+++ b/30_skinning_part_one/gl_utils.cpp
@@ -101,7 +101,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -125,7 +125,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/30_skinning_part_one/gl_utils.h
+++ b/30_skinning_part_one/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/31_skinning_part_two/gl_utils.cpp
+++ b/31_skinning_part_two/gl_utils.cpp
@@ -101,7 +101,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -125,7 +125,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/31_skinning_part_two/gl_utils.h
+++ b/31_skinning_part_two/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/32_skinnng_part_three/gl_utils.cpp
+++ b/32_skinnng_part_three/gl_utils.cpp
@@ -101,7 +101,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -125,7 +125,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/32_skinnng_part_three/gl_utils.h
+++ b/32_skinnng_part_three/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/34_framebuffer_switch/gl_utils.cpp
+++ b/34_framebuffer_switch/gl_utils.cpp
@@ -101,7 +101,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -125,7 +125,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/34_framebuffer_switch/gl_utils.h
+++ b/34_framebuffer_switch/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/35_image_kernel/gl_utils.cpp
+++ b/35_image_kernel/gl_utils.cpp
@@ -101,7 +101,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 	glfwWindowHint( GLFW_SAMPLES, 4 );
 
@@ -124,9 +124,10 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
+	glfwGetFramebufferSize( window, &g_gl_width, &g_gl_height );
 	printf( "width %i height %i\n", width, height );
 	/* update any perspective matrices used here */
 }

--- a/35_image_kernel/gl_utils.h
+++ b/35_image_kernel/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/36_colour_picking/gl_utils.cpp
+++ b/36_colour_picking/gl_utils.cpp
@@ -101,7 +101,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -125,7 +125,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/36_colour_picking/gl_utils.h
+++ b/36_colour_picking/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/37_deferred_shading/gl_utils.cpp
+++ b/37_deferred_shading/gl_utils.cpp
@@ -101,7 +101,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 4 );
@@ -125,7 +125,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/37_deferred_shading/gl_utils.h
+++ b/37_deferred_shading/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/38_texture_shadows/gl_utils.cpp
+++ b/38_texture_shadows/gl_utils.cpp
@@ -106,7 +106,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	glfwWindowHint( GLFW_SAMPLES, 16 );
@@ -130,9 +130,10 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
+	glfwGetFramebufferSize( window, &g_gl_width, &g_gl_height );
 	printf( "width %i height %i\n", width, height );
 	/* update any perspective matrices used here */
 }

--- a/38_texture_shadows/gl_utils.h
+++ b/38_texture_shadows/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );

--- a/39_texture_mapping_srgb/gl_utils.cpp
+++ b/39_texture_mapping_srgb/gl_utils.cpp
@@ -103,7 +103,7 @@ bool start_gl() {
 		glfwTerminate();
 		return false;
 	}
-	glfwSetWindowSizeCallback( g_window, glfw_window_size_callback );
+	glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
 	glfwMakeContextCurrent( g_window );
 
 	// start GLEW extension handler
@@ -125,7 +125,7 @@ void glfw_error_callback( int error, const char *description ) {
 	gl_log_err( "%s\n", description );
 }
 // a call-back function
-void glfw_window_size_callback( GLFWwindow *window, int width, int height ) {
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height ) {
 	g_gl_width = width;
 	g_gl_height = height;
 	printf( "width %i height %i\n", width, height );

--- a/39_texture_mapping_srgb/gl_utils.h
+++ b/39_texture_mapping_srgb/gl_utils.h
@@ -31,7 +31,7 @@ bool gl_log_err( const char *message, ... );
 /*--------------------------------GLFW3 and GLEW------------------------------*/
 bool start_gl();
 void glfw_error_callback( int error, const char *description );
-void glfw_window_size_callback( GLFWwindow *window, int width, int height );
+void glfw_framebuffer_size_callback( GLFWwindow *window, int width, int height );
 void _update_fps_counter( GLFWwindow *window );
 /*-----------------------------------SHADERS----------------------------------*/
 bool parse_file_into_str( const char *file_name, char *shader_str, int max_len );


### PR DESCRIPTION
Hi,

This fix is related to GLFW and macOS with retina displays where [screen coordinates and pixels do not map 1:1](http://www.glfw.org/faq.html#why-is-my-output-in-the-lower-left-corner-of-the-window)
