### PR TITLE
Add CMakeLists for folders 00 to 03

### DIFF
--- a/00_hello_triangle/CMakeLists.txt
+++ b/00_hello_triangle/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.6)   # CMake version check
+project(antons_tutorials C CXX)               # Create project "simple_example"
+set(CMAKE_CXX_STANDARD 11)            # Enable c++11 standard
+
+#add source folder so the program can be compiled at build folder
+include_directories(${CMAKE_SOURCE_DIR})
+
+#Headers
+file(GLOB HEADERS
+  *.h
+  )
+
+#Main
+set(SOURCE_FILES main.c)
+add_executable(main ${SOURCE_FILES} ${HEADERS})
+
+#OpenGL
+find_package(OpenGL REQUIRED)
+include_directories(${OPENGL_INCLUDE_DIR})
+
+target_link_libraries(main ${OPENGL_gl_LIBRARY})
+
+
+#GLFW
+find_package(PkgConfig REQUIRED)
+pkg_search_module(GLFW REQUIRED glfw3)
+include_directories(${GLFW_INCLUDE_DIRS})
+target_link_libraries(main ${GLFW_LIBRARIES})
+
+#GLEW
+find_package(GLEW REQUIRED)
+if (GLEW_FOUND)
+    include_directories(${GLEW_INCLUDE_DIRS})
+    target_link_libraries(main ${GLEW_LIBRARIES})
+endif()
+
+
+

--- a/00_hello_triangle/CMakeLists.txt
+++ b/00_hello_triangle/CMakeLists.txt
@@ -12,26 +12,26 @@ file(GLOB HEADERS
 
 #Main
 set(SOURCE_FILES main.c)
-add_executable(main ${SOURCE_FILES} ${HEADERS})
+add_executable(hellot ${SOURCE_FILES} ${HEADERS})
 
 #OpenGL
 find_package(OpenGL REQUIRED)
 include_directories(${OPENGL_INCLUDE_DIR})
 
-target_link_libraries(main ${OPENGL_gl_LIBRARY})
+target_link_libraries(hellot ${OPENGL_gl_LIBRARY})
 
 
 #GLFW
 find_package(PkgConfig REQUIRED)
 pkg_search_module(GLFW REQUIRED glfw3)
 include_directories(${GLFW_INCLUDE_DIRS})
-target_link_libraries(main ${GLFW_LIBRARIES})
+target_link_libraries(hellot ${GLFW_LIBRARIES})
 
 #GLEW
 find_package(GLEW REQUIRED)
 if (GLEW_FOUND)
     include_directories(${GLEW_INCLUDE_DIRS})
-    target_link_libraries(main ${GLEW_LIBRARIES})
+    target_link_libraries(hellot ${GLEW_LIBRARIES})
 endif()
 
 

--- a/01_extended_init/CMakeLists.txt
+++ b/01_extended_init/CMakeLists.txt
@@ -34,12 +34,6 @@ if (GLEW_FOUND)
     target_link_libraries(main ${GLEW_LIBRARIES})
   endif()
 
-#GLUT
-find_package(GLUT REQUIRED)
-if (GLUT_FOUND)
-    include_directories(${GLUT_INCLUDE_DIRS})
-    target_link_libraries(main ${GLUT_LIBRARIES})    
-endif()
 
 
 

--- a/01_extended_init/CMakeLists.txt
+++ b/01_extended_init/CMakeLists.txt
@@ -12,26 +12,26 @@ file(GLOB HEADERS
 
 #Main
 set(SOURCE_FILES main.c)
-add_executable(main ${SOURCE_FILES} ${HEADERS})
+add_executable(extinit ${SOURCE_FILES} ${HEADERS})
 
 #OpenGL
 find_package(OpenGL REQUIRED)
 include_directories(${OPENGL_INCLUDE_DIR})
 
-target_link_libraries(main ${OPENGL_gl_LIBRARY})
+target_link_libraries(extinit ${OPENGL_gl_LIBRARY})
 
 
 #GLFW
 find_package(PkgConfig REQUIRED)
 pkg_search_module(GLFW REQUIRED glfw3)
 include_directories(${GLFW_INCLUDE_DIRS})
-target_link_libraries(main ${GLFW_LIBRARIES})
+target_link_libraries(extinit ${GLFW_LIBRARIES})
 
 #GLEW
 find_package(GLEW REQUIRED)
 if (GLEW_FOUND)
     include_directories(${GLEW_INCLUDE_DIRS})
-    target_link_libraries(main ${GLEW_LIBRARIES})
+    target_link_libraries(extinit ${GLEW_LIBRARIES})
   endif()
 
 

--- a/01_extended_init/CMakeLists.txt
+++ b/01_extended_init/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 3.6)   # CMake version check
+project(antons_tutorials C CXX)               # Create project "simple_example"
+set(CMAKE_CXX_STANDARD 11)            # Enable c++11 standard
+
+#add source folder so the program can be compiled at build folder
+include_directories(${CMAKE_SOURCE_DIR})
+
+#Headers
+file(GLOB HEADERS
+  *.h
+  )
+
+#Main
+set(SOURCE_FILES main.c)
+add_executable(main ${SOURCE_FILES} ${HEADERS})
+
+#OpenGL
+find_package(OpenGL REQUIRED)
+include_directories(${OPENGL_INCLUDE_DIR})
+
+target_link_libraries(main ${OPENGL_gl_LIBRARY})
+
+
+#GLFW
+find_package(PkgConfig REQUIRED)
+pkg_search_module(GLFW REQUIRED glfw3)
+include_directories(${GLFW_INCLUDE_DIRS})
+target_link_libraries(main ${GLFW_LIBRARIES})
+
+#GLEW
+find_package(GLEW REQUIRED)
+if (GLEW_FOUND)
+    include_directories(${GLEW_INCLUDE_DIRS})
+    target_link_libraries(main ${GLEW_LIBRARIES})
+  endif()
+
+#GLUT
+find_package(GLUT REQUIRED)
+if (GLUT_FOUND)
+    include_directories(${GLUT_INCLUDE_DIRS})
+    target_link_libraries(main ${GLUT_LIBRARIES})    
+endif()
+
+
+

--- a/02_shaders/CMakeLists.txt
+++ b/02_shaders/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.6)   # CMake version check
+project(antons_tutorials C CXX)               # Create project "simple_example"
+set(CMAKE_CXX_STANDARD 11)            # Enable c++11 standard
+
+#add source folder so the program can be compiled at build folder
+include_directories(${CMAKE_SOURCE_DIR})
+
+#Headers
+file(GLOB HEADERS
+  *.h
+  *.c
+  )
+
+#Main
+set(SOURCE_FILES main.c)
+add_executable(main ${SOURCE_FILES} ${HEADERS})
+
+#OpenGL
+find_package(OpenGL REQUIRED)
+include_directories(${OPENGL_INCLUDE_DIR})
+
+target_link_libraries(main ${OPENGL_gl_LIBRARY})
+
+
+#GLFW
+find_package(PkgConfig REQUIRED)
+pkg_search_module(GLFW REQUIRED glfw3)
+include_directories(${GLFW_INCLUDE_DIRS})
+target_link_libraries(main ${GLFW_LIBRARIES})
+
+#GLEW
+find_package(GLEW REQUIRED)
+if (GLEW_FOUND)
+    include_directories(${GLEW_INCLUDE_DIRS})
+    target_link_libraries(main ${GLEW_LIBRARIES})
+endif()
+
+
+

--- a/02_shaders/CMakeLists.txt
+++ b/02_shaders/CMakeLists.txt
@@ -13,26 +13,26 @@ file(GLOB HEADERS
 
 #Main
 set(SOURCE_FILES main.c)
-add_executable(main ${SOURCE_FILES} ${HEADERS})
+add_executable(shaders ${SOURCE_FILES} ${HEADERS})
 
 #OpenGL
 find_package(OpenGL REQUIRED)
 include_directories(${OPENGL_INCLUDE_DIR})
 
-target_link_libraries(main ${OPENGL_gl_LIBRARY})
+target_link_libraries(shaders ${OPENGL_gl_LIBRARY})
 
 
 #GLFW
 find_package(PkgConfig REQUIRED)
 pkg_search_module(GLFW REQUIRED glfw3)
 include_directories(${GLFW_INCLUDE_DIRS})
-target_link_libraries(main ${GLFW_LIBRARIES})
+target_link_libraries(shaders ${GLFW_LIBRARIES})
 
 #GLEW
 find_package(GLEW REQUIRED)
 if (GLEW_FOUND)
     include_directories(${GLEW_INCLUDE_DIRS})
-    target_link_libraries(main ${GLEW_LIBRARIES})
+    target_link_libraries(shaders ${GLEW_LIBRARIES})
 endif()
 
 

--- a/03_vertex_buffer_objects/CMakeLists.txt
+++ b/03_vertex_buffer_objects/CMakeLists.txt
@@ -14,26 +14,26 @@ file(GLOB HEADERS
 
 #Main
 set(SOURCE_FILES main.cpp)
-add_executable(main ${SOURCE_FILES} ${HEADERS})
+add_executable(vbuffs ${SOURCE_FILES} ${HEADERS})
 
 #OpenGL
 find_package(OpenGL REQUIRED)
 include_directories(${OPENGL_INCLUDE_DIR})
 
-target_link_libraries(main ${OPENGL_gl_LIBRARY})
+target_link_libraries(vbuffs ${OPENGL_gl_LIBRARY})
 
 
 #GLFW
 find_package(PkgConfig REQUIRED)
 pkg_search_module(GLFW REQUIRED glfw3)
 include_directories(${GLFW_INCLUDE_DIRS})
-target_link_libraries(main ${GLFW_LIBRARIES})
+target_link_libraries(vbuffs ${GLFW_LIBRARIES})
 
 #GLEW
 find_package(GLEW REQUIRED)
 if (GLEW_FOUND)
     include_directories(${GLEW_INCLUDE_DIRS})
-    target_link_libraries(main ${GLEW_LIBRARIES})
+    target_link_libraries(vbuffs ${GLEW_LIBRARIES})
 endif()
 
 

--- a/03_vertex_buffer_objects/CMakeLists.txt
+++ b/03_vertex_buffer_objects/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.6)   # CMake version check
+project(antons_tutorials C CXX)               # Create project "simple_example"
+set(CMAKE_CXX_STANDARD 11)            # Enable c++11 standard
+
+#add source folder so the program can be compiled at build folder
+include_directories(${CMAKE_SOURCE_DIR})
+
+#Headers
+file(GLOB HEADERS
+  *.h
+  *.c
+  *.cpp
+  )
+
+#Main
+set(SOURCE_FILES main.cpp)
+add_executable(main ${SOURCE_FILES} ${HEADERS})
+
+#OpenGL
+find_package(OpenGL REQUIRED)
+include_directories(${OPENGL_INCLUDE_DIR})
+
+target_link_libraries(main ${OPENGL_gl_LIBRARY})
+
+
+#GLFW
+find_package(PkgConfig REQUIRED)
+pkg_search_module(GLFW REQUIRED glfw3)
+include_directories(${GLFW_INCLUDE_DIRS})
+target_link_libraries(main ${GLFW_LIBRARIES})
+
+#GLEW
+find_package(GLEW REQUIRED)
+if (GLEW_FOUND)
+    include_directories(${GLEW_INCLUDE_DIRS})
+    target_link_libraries(main ${GLEW_LIBRARIES})
+endif()
+
+
+

--- a/32_skinnng_part_three/CMakeLists.txt
+++ b/32_skinnng_part_three/CMakeLists.txt
@@ -1,0 +1,56 @@
+cmake_minimum_required(VERSION 3.6)   # CMake version check
+project(antons_tutorials C CXX)               # Create project "simple_example"
+set(CMAKE_CXX_STANDARD 11)            # Enable c++11 standard
+
+#add source folder so the program can be compiled at build folder
+include_directories(${CMAKE_SOURCE_DIR} "../common/include")
+#include_directories(${antons_tutorials_SOURCE_DIR})
+
+
+#Headers
+file(GLOB HEADERS
+  *.h
+  *.cpp
+  )
+
+#Main
+set(SOURCE_FILES main.cpp maths_funcs.cpp gl_utils.cpp)
+add_executable(main ${SOURCE_FILES} ${HEADERS})
+
+#OpenGL
+find_package(OpenGL REQUIRED)
+include_directories(${OPENGL_INCLUDE_DIR})
+
+target_link_libraries(main ${OPENGL_gl_LIBRARY})
+
+
+#GLFW
+find_package(PkgConfig REQUIRED)
+pkg_search_module(GLFW REQUIRED glfw3)
+include_directories(${GLFW_INCLUDE_DIRS})
+target_link_libraries(main ${GLFW_LIBRARIES})
+
+
+#ASSIMP
+find_package(ASSIMP REQUIRED)
+if (ASSIMP_FOUND)
+    include_directories(${ASSIMP_INCLUDE_DIRS})
+    target_link_libraries(main ${ASSIMP_LIBRARIES})
+  endif()
+
+#GLEW
+find_package(GLEW REQUIRED)
+if (GLEW_FOUND)
+    include_directories(${GLEW_INCLUDE_DIRS})
+    target_link_libraries(main ${GLEW_LIBRARIES})
+  endif()
+
+#GLUT
+find_package(GLUT REQUIRED)
+if (GLUT_FOUND)
+    include_directories(${GLUT_INCLUDE_DIRS})
+    target_link_libraries(main ${GLUT_LIBRARIES})    
+endif()
+
+
+


### PR DESCRIPTION
Tested on Ubuntu 18.04. Some executables need to be moved to the root folder if you build in a separate folder (for shader access).