### PR TITLE
Simplified perspective matrix calculation

### DIFF
--- a/03_vertex_buffer_objects/maths_funcs.cpp
+++ b/03_vertex_buffer_objects/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/04_mats_and_vecs/maths_funcs.cpp
+++ b/04_mats_and_vecs/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/05_virtual_camera/main.cpp
+++ b/05_virtual_camera/main.cpp
@@ -116,9 +116,9 @@ int main() {
 	float fov = 67.0f * ONE_DEG_IN_RAD; // convert 67 degrees to radians
 	float aspect = (float)g_gl_width / (float)g_gl_height; // aspect ratio
 	// matrix components
-	float range = tan( fov * 0.5f ) * near;
-	float Sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float Sy = near / range;
+	float inverse_range = 1.0f / tan( fov * 0.5f );
+	float Sx = inverse_range / aspect;
+	float Sy = inverse_range;
 	float Sz = -( far + near ) / ( far - near );
 	float Pz = -( 2.0f * far * near ) / ( far - near );
 	GLfloat proj_mat[] = { Sx,	 0.0f, 0.0f, 0.0f,	0.0f, Sy,		0.0f, 0.0f,

--- a/05_virtual_camera/maths_funcs.cpp
+++ b/05_virtual_camera/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/06_vcam_with_quaternion/maths_funcs.cpp
+++ b/06_vcam_with_quaternion/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/07_ray_picking/maths_funcs.cpp
+++ b/07_ray_picking/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/08_phong/main.cpp
+++ b/08_phong/main.cpp
@@ -73,9 +73,9 @@ int main() {
 	float fov = 67.0f * ONE_DEG_IN_RAD; // convert 67 degrees to radians
 	float aspect = (float)g_gl_width / (float)g_gl_height; // aspect ratio
 	// matrix components
-	float range = tan( fov * 0.5f ) * near;
-	float Sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float Sy = near / range;
+	float inverse_range = 1.0f / tan( fov * 0.5f );
+	float Sx = inverse_range / aspect;
+	float Sy = inverse_range;
 	float Sz = -( far + near ) / ( far - near );
 	float Pz = -( 2.0f * far * near ) / ( far - near );
 	GLfloat proj_mat[] = { Sx,	 0.0f, 0.0f, 0.0f,	0.0f, Sy,		0.0f, 0.0f,

--- a/08_phong/maths_funcs.cpp
+++ b/08_phong/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/09_texture_mapping/main.cpp
+++ b/09_texture_mapping/main.cpp
@@ -111,9 +111,9 @@ int main() {
 	float fov = 67.0f * ONE_DEG_IN_RAD; // convert 67 degrees to radians
 	float aspect = (float)g_gl_width / (float)g_gl_height; // aspect ratio
 	// matrix components
-	float range = tan( fov * 0.5f ) * near;
-	float Sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float Sy = near / range;
+	float inverse_range = 1.0f / tan( fov * 0.5f );
+	float Sx = inverse_range / aspect;
+	float Sy = inverse_range;
 	float Sz = -( far + near ) / ( far - near );
 	float Pz = -( 2.0f * far * near ) / ( far - near );
 	GLfloat proj_mat[] = { Sx,	 0.0f, 0.0f, 0.0f,	0.0f, Sy,		0.0f, 0.0f,

--- a/09_texture_mapping/maths_funcs.cpp
+++ b/09_texture_mapping/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/10_screen_capture/main.cpp
+++ b/10_screen_capture/main.cpp
@@ -141,9 +141,9 @@ int main() {
 	float fov = 67.0f * ONE_DEG_IN_RAD; // convert 67 degrees to radians
 	float aspect = (float)g_gl_width / (float)g_gl_height; // aspect ratio
 	// matrix components
-	float range = tan( fov * 0.5f ) * near;
-	float Sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float Sy = near / range;
+	float inverse_range = 1.0f / tan( fov * 0.5f );
+	float Sx = inverse_range / aspect;
+	float Sy = inverse_range;
 	float Sz = -( far + near ) / ( far - near );
 	float Pz = -( 2.0f * far * near ) / ( far - near );
 	GLfloat proj_mat[] = { Sx,	 0.0f, 0.0f, 0.0f,	0.0f, Sy,		0.0f, 0.0f,

--- a/10_screen_capture/maths_funcs.cpp
+++ b/10_screen_capture/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/11_video_capture/main.cpp
+++ b/11_video_capture/main.cpp
@@ -183,9 +183,9 @@ int main() {
 	float fov = 67.0f * ONE_DEG_IN_RAD; // convert 67 degrees to radians
 	float aspect = (float)g_gl_width / (float)g_gl_height; // aspect ratio
 	// matrix components
-	float range = tan( fov * 0.5f ) * near;
-	float Sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float Sy = near / range;
+	float inverse_range = 1.0f / tan( fov * 0.5f );
+	float Sx = inverse_range / aspect;
+	float Sy = inverse_range;
 	float Sz = -( far + near ) / ( far - near );
 	float Pz = -( 2.0f * far * near ) / ( far - near );
 	GLfloat proj_mat[] = { Sx,	 0.0f, 0.0f, 0.0f,	0.0f, Sy,		0.0f, 0.0f,

--- a/11_video_capture/maths_funcs.cpp
+++ b/11_video_capture/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/12_debugging_shaders/main.cpp
+++ b/12_debugging_shaders/main.cpp
@@ -182,9 +182,9 @@ int main() {
 	float fov = 67.0f * ONE_DEG_IN_RAD; // convert 67 degrees to radians
 	float aspect = (float)g_gl_width / (float)g_gl_height; // aspect ratio
 	// matrix components
-	float range = tan( fov * 0.5f ) * near;
-	float Sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float Sy = near / range;
+	float inverse_range = 1.0f / tan( fov * 0.5f );
+	float Sx = inverse_range / aspect;
+	float Sy = inverse_range;
 	float Sz = -( far + near ) / ( far - near );
 	float Pz = -( 2.0f * far * near ) / ( far - near );
 	GLfloat proj_mat[] = { Sx,	 0.0f, 0.0f, 0.0f,	0.0f, Sy,		0.0f, 0.0f,

--- a/12_debugging_shaders/maths_funcs.cpp
+++ b/12_debugging_shaders/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/13_mesh_import/main.cpp
+++ b/13_mesh_import/main.cpp
@@ -163,9 +163,9 @@ int main() {
 	float fov = 67.0f * ONE_DEG_IN_RAD; // convert 67 degrees to radians
 	float aspect = (float)g_gl_width / (float)g_gl_height; // aspect ratio
 	// matrix components
-	float range = tan( fov * 0.5f ) * near;
-	float Sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float Sy = near / range;
+	float inverse_range = 1.0f / tan( fov * 0.5f );
+	float Sx = inverse_range / aspect;
+	float Sy = inverse_range;
 	float Sz = -( far + near ) / ( far - near );
 	float Pz = -( 2.0f * far * near ) / ( far - near );
 	GLfloat proj_mat[] = { Sx,	 0.0f, 0.0f, 0.0f,	0.0f, Sy,		0.0f, 0.0f,

--- a/13_mesh_import/maths_funcs.cpp
+++ b/13_mesh_import/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/14_multi_tex/main.cpp
+++ b/14_multi_tex/main.cpp
@@ -123,9 +123,9 @@ int main() {
 	float fov = 67.0f * ONE_DEG_IN_RAD; // convert 67 degrees to radians
 	float aspect = (float)g_gl_width / (float)g_gl_height; // aspect ratio
 	// matrix components
-	float range = tan( fov * 0.5f ) * near;
-	float Sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float Sy = near / range;
+	float inverse_range = 1.0f / tan( fov * 0.5f );
+	float Sx = inverse_range / aspect;
+	float Sy = inverse_range;
 	float Sz = -( far + near ) / ( far - near );
 	float Pz = -( 2.0f * far * near ) / ( far - near );
 	GLfloat proj_mat[] = { Sx,	 0.0f, 0.0f, 0.0f,	0.0f, Sy,		0.0f, 0.0f,

--- a/14_multi_tex/maths_funcs.cpp
+++ b/14_multi_tex/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/15_phongtextures/main.cpp
+++ b/15_phongtextures/main.cpp
@@ -230,9 +230,9 @@ int main() {
 	float fov = 67.0f * ONE_DEG_IN_RAD; // convert 67 degrees to radians
 	float aspect = (float)g_gl_width / (float)g_gl_height; // aspect ratio
 	// matrix components
-	float range = tan( fov * 0.5f ) * near;
-	float Sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float Sy = near / range;
+	float inverse_range = 1.0f / tan( fov * 0.5f );
+	float Sx = inverse_range / aspect;
+	float Sy = inverse_range;
 	float Sz = -( far + near ) / ( far - near );
 	float Pz = -( 2.0f * far * near ) / ( far - near );
 	GLfloat proj_mat[] = { Sx,	 0.0f, 0.0f, 0.0f,	0.0f, Sy,		0.0f, 0.0f,

--- a/15_phongtextures/maths_funcs.cpp
+++ b/15_phongtextures/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/16_frag_reject/main.cpp
+++ b/16_frag_reject/main.cpp
@@ -117,9 +117,9 @@ int main() {
 	float fov = 67.0f * ONE_DEG_IN_RAD; // convert 67 degrees to radians
 	float aspect = (float)g_gl_width / (float)g_gl_height; // aspect ratio
 	// matrix components
-	float range = tan( fov * 0.5f ) * near;
-	float Sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float Sy = near / range;
+	float inverse_range = 1.0f / tan( fov * 0.5f );
+	float Sx = inverse_range / aspect;
+	float Sy = inverse_range;
 	float Sz = -( far + near ) / ( far - near );
 	float Pz = -( 2.0f * far * near ) / ( far - near );
 	GLfloat proj_mat[] = { Sx,	 0.0f, 0.0f, 0.0f,	0.0f, Sy,		0.0f, 0.0f,

--- a/16_frag_reject/maths_funcs.cpp
+++ b/16_frag_reject/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/17_alpha_blending/main.cpp
+++ b/17_alpha_blending/main.cpp
@@ -117,9 +117,9 @@ int main() {
 	float fov = 67.0f * ONE_DEG_IN_RAD; // convert 67 degrees to radians
 	float aspect = (float)g_gl_width / (float)g_gl_height; // aspect ratio
 	// matrix components
-	float range = tan( fov * 0.5f ) * near;
-	float Sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float Sy = near / range;
+	float inverse_range = 1.0f / tan( fov * 0.5f );
+	float Sx = inverse_range / aspect;
+	float Sy = inverse_range;
 	float Sz = -( far + near ) / ( far - near );
 	float Pz = -( 2.0f * far * near ) / ( far - near );
 	GLfloat proj_mat[] = { Sx,	 0.0f, 0.0f, 0.0f,	0.0f, Sy,		0.0f, 0.0f,

--- a/17_alpha_blending/maths_funcs.cpp
+++ b/17_alpha_blending/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/18_spotlights/main.cpp
+++ b/18_spotlights/main.cpp
@@ -68,9 +68,9 @@ int main() {
 	float fov = 67.0f * ONE_DEG_IN_RAD; // convert 67 degrees to radians
 	float aspect = (float)g_gl_width / (float)g_gl_height; // aspect ratio
 	// matrix components
-	float range = tan( fov * 0.5f ) * near;
-	float Sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float Sy = near / range;
+	float inverse_range = 1.0f / tan( fov * 0.5f );
+	float Sx = inverse_range / aspect;
+	float Sy = inverse_range;
 	float Sz = -( far + near ) / ( far - near );
 	float Pz = -( 2.0f * far * near ) / ( far - near );
 	GLfloat proj_mat[] = { Sx,	 0.0f, 0.0f, 0.0f,	0.0f, Sy,		0.0f, 0.0f,

--- a/18_spotlights/maths_funcs.cpp
+++ b/18_spotlights/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/19_fog/main.cpp
+++ b/19_fog/main.cpp
@@ -153,9 +153,9 @@ int main() {
 	float fov = 67.0f * ONE_DEG_IN_RAD; // convert 67 degrees to radians
 	float aspect = (float)g_gl_width / (float)g_gl_height; // aspect ratio
 	// matrix components
-	float range = tan( fov * 0.5f ) * near;
-	float Sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float Sy = near / range;
+	float inverse_range = 1.0f / tan( fov * 0.5f );
+	float Sx = inverse_range / aspect;
+	float Sy = inverse_range;
 	float Sz = -( far + near ) / ( far - near );
 	float Pz = -( 2.0f * far * near ) / ( far - near );
 	GLfloat proj_mat[] = { Sx,	 0.0f, 0.0f, 0.0f,	0.0f, Sy,		0.0f, 0.0f,

--- a/19_fog/maths_funcs.cpp
+++ b/19_fog/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/20_normal_mapping/main.cpp
+++ b/20_normal_mapping/main.cpp
@@ -191,9 +191,9 @@ int main() {
 	float fov = 67.0f * ONE_DEG_IN_RAD; // convert 67 degrees to radians
 	float aspect = (float)g_gl_width / (float)g_gl_height; // aspect ratio
 	// matrix components
-	float range = tan( fov * 0.5f ) * near;
-	float Sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float Sy = near / range;
+	float inverse_range = 1.0f / tan( fov * 0.5f );
+	float Sx = inverse_range / aspect;
+	float Sy = inverse_range;
 	float Sz = -( far + near ) / ( far - near );
 	float Pz = -( 2.0f * far * near ) / ( far - near );
 	GLfloat proj_mat[] = { Sx,	 0.0f, 0.0f, 0.0f,	0.0f, Sy,		0.0f, 0.0f,

--- a/20_normal_mapping/maths_funcs.cpp
+++ b/20_normal_mapping/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/21_cube_mapping/maths_funcs.cpp
+++ b/21_cube_mapping/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/22_geom_shaders/maths_funcs.cpp
+++ b/22_geom_shaders/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/23_tessellation_shaders/maths_funcs.cpp
+++ b/23_tessellation_shaders/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/24_gui_panels/maths_funcs.cpp
+++ b/24_gui_panels/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/25_sprite_sheets/maths_funcs.cpp
+++ b/25_sprite_sheets/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/26_bitmap_fonts/maths_funcs.cpp
+++ b/26_bitmap_fonts/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/27_font_atlas/maths_funcs.cpp
+++ b/27_font_atlas/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/28_uniform_buffer_object/maths_funcs.cpp
+++ b/28_uniform_buffer_object/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/29_particle_systems/main.cpp
+++ b/29_particle_systems/main.cpp
@@ -87,9 +87,9 @@ int main() {
 	float fov = 67.0f * ONE_DEG_IN_RAD; // convert 67 degrees to radians
 	float aspect = (float)g_gl_width / (float)g_gl_height; // aspect ratio
 	// matrix components
-	float range = tan( fov * 0.5f ) * near;
-	float Sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float Sy = near / range;
+	float inverse_range = 1.0f / tan( fov * 0.5f );
+	float Sx = inverse_range / aspect;
+	float Sy = inverse_range;
 	float Sz = -( far + near ) / ( far - near );
 	float Pz = -( 2.0f * far * near ) / ( far - near );
 	GLfloat proj_mat[] = { Sx,	 0.0f, 0.0f, 0.0f,	0.0f, Sy,		0.0f, 0.0f,

--- a/29_particle_systems/maths_funcs.cpp
+++ b/29_particle_systems/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/30_skinning_part_one/main.cpp
+++ b/30_skinning_part_one/main.cpp
@@ -251,9 +251,9 @@ int main() {
 	float fov = 67.0f * ONE_DEG_IN_RAD; // convert 67 degrees to radians
 	float aspect = (float)g_gl_width / (float)g_gl_height; // aspect ratio
 	// matrix components
-	float range = tan( fov * 0.5f ) * near;
-	float Sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float Sy = near / range;
+	float inverse_range = 1.0f / tan( fov * 0.5f );
+	float Sx = inverse_range / aspect;
+	float Sy = inverse_range;
 	float Sz = -( far + near ) / ( far - near );
 	float Pz = -( 2.0f * far * near ) / ( far - near );
 	GLfloat proj_mat[] = { Sx,	 0.0f, 0.0f, 0.0f,	0.0f, Sy,		0.0f, 0.0f,

--- a/30_skinning_part_one/maths_funcs.cpp
+++ b/30_skinning_part_one/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/31_skinning_part_two/main.cpp
+++ b/31_skinning_part_two/main.cpp
@@ -382,9 +382,9 @@ int main() {
 	float fov = 67.0f * ONE_DEG_IN_RAD; // convert 67 degrees to radians
 	float aspect = (float)g_gl_width / (float)g_gl_height; // aspect ratio
 	// matrix components
-	float range = tan( fov * 0.5f ) * near;
-	float Sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float Sy = near / range;
+	float inverse_range = 1.0f / tan( fov * 0.5f );
+	float Sx = inverse_range / aspect;
+	float Sy = inverse_range;
 	float Sz = -( far + near ) / ( far - near );
 	float Pz = -( 2.0f * far * near ) / ( far - near );
 	GLfloat proj_mat[] = { Sx,	 0.0f, 0.0f, 0.0f,	0.0f, Sy,		0.0f, 0.0f,

--- a/31_skinning_part_two/maths_funcs.cpp
+++ b/31_skinning_part_two/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/32_skinnng_part_three/main.cpp
+++ b/32_skinnng_part_three/main.cpp
@@ -536,9 +536,9 @@ int main() {
 	float fov = 67.0f * ONE_DEG_IN_RAD; // convert 67 degrees to radians
 	float aspect = (float)g_gl_width / (float)g_gl_height; // aspect ratio
 	// matrix components
-	float range = tan( fov * 0.5f ) * near;
-	float Sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float Sy = near / range;
+	float inverse_range = 1.0f / tan( fov * 0.5f );
+	float Sx = inverse_range / aspect;
+	float Sy = inverse_range;
 	float Sz = -( far + near ) / ( far - near );
 	float Pz = -( 2.0f * far * near ) / ( far - near );
 	GLfloat proj_mat[] = { Sx,	 0.0f, 0.0f, 0.0f,	0.0f, Sy,		0.0f, 0.0f,

--- a/32_skinnng_part_three/maths_funcs.cpp
+++ b/32_skinnng_part_three/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/34_framebuffer_switch/maths_funcs.cpp
+++ b/34_framebuffer_switch/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/35_image_kernel/maths_funcs.cpp
+++ b/35_image_kernel/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/36_colour_picking/maths_funcs.cpp
+++ b/36_colour_picking/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/37_deferred_shading/maths_funcs.cpp
+++ b/37_deferred_shading/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/38_texture_shadows/maths_funcs.cpp
+++ b/38_texture_shadows/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/39_texture_mapping_srgb/main.cpp
+++ b/39_texture_mapping_srgb/main.cpp
@@ -124,9 +124,9 @@ int main() {
 	float fov = 67.0f * ONE_DEG_IN_RAD; // convert 67 degrees to radians
 	float aspect = (float)g_gl_width / (float)g_gl_height; // aspect ratio
 	// matrix components
-	float range = tan( fov * 0.5f ) * near;
-	float Sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float Sy = near / range;
+	float inverse_range = 1.0f / tan( fov * 0.5f );
+	float Sx = inverse_range / aspect;
+	float Sy = inverse_range;
 	float Sz = -( far + near ) / ( far - near );
 	float Pz = -( 2.0f * far * near ) / ( far - near );
 	GLfloat proj_mat[] = { Sx,	 0.0f, 0.0f, 0.0f,	0.0f, Sy,		0.0f, 0.0f,

--- a/39_texture_mapping_srgb/maths_funcs.cpp
+++ b/39_texture_mapping_srgb/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/common/maths_funcs.cpp
+++ b/common/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero

--- a/visual_studio/maths_funcs.cpp
+++ b/visual_studio/maths_funcs.cpp
@@ -512,9 +512,9 @@ mat4 look_at( const vec3 &cam_pos, vec3 targ_pos, const vec3 &up ) {
 // returns a perspective function mimicking the opengl projection style.
 mat4 perspective( float fovy, float aspect, float near, float far ) {
 	float fov_rad = fovy * ONE_DEG_IN_RAD;
-	float range = tan( fov_rad / 2.0f ) * near;
-	float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
-	float sy = near / range;
+	float inverse_range = 1.0f / tan( fov_rad / 2.0f );
+	float sx = inverse_range / aspect;
+	float sy = inverse_range;
 	float sz = -( far + near ) / ( far - near );
 	float pz = -( 2.0f * far * near ) / ( far - near );
 	mat4 m = zero_mat4(); // make sure bottom-right corner is zero


### PR DESCRIPTION
The x- and y-scales for the perspective matrix are calculated like so:
```
float range = tan( fov_rad / 2.0f ) * near;
float sx = ( 2.0f * near ) / ( range * aspect + range * aspect );
float sy = near / range;
```

The denominator of `sx` can be added:
```
float range = tan( fov_rad / 2.0f ) * near;
float sx = ( 2.0f * near ) / (2.0f * range * aspect  );
float sy = near / range;
```

Cancel the `2.0f` on top and bottom:
```
float range = tan( fov_rad / 2.0f ) * near;
float sx = near / ( range * aspect  );
float sy = near / range;
```

Inline the `range` variable:
```
float sx = near / ( tan( fov_rad / 2.0f ) * near * aspect  );
float sy = near / ( tan( fov_rad / 2.0f ) * near );
```

Cancel `near` on top and bottom:
```
float sx = 1.0f / ( tan( fov_rad / 2.0f ) * aspect  );
float sy = 1.0f / ( tan( fov_rad / 2.0f ) );
```

Factor out the common inverse_range:
```
float inverse_range = 1.0f / tan( fov_rad / 2.0f );
float sx = inverse_range / aspect;
float sy = inverse_range;
```