### PR TITLE
Move glfwWindowHint, so it is called before the window is created

### DIFF
--- a/02_shaders/gl_utils.c
+++ b/02_shaders/gl_utils.c
@@ -89,6 +89,8 @@ bool start_gl() {
   glfwWindowHint( GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE );
   glfwWindowHint( GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE );
 
+  glfwWindowHint( GLFW_SAMPLES, 4 );
+
   /*GLFWmonitor* mon = glfwGetPrimaryMonitor ();
   const GLFWvidmode* vmode = glfwGetVideoMode (mon);
   g_window = glfwCreateWindow (
@@ -104,7 +106,6 @@ bool start_gl() {
   glfwSetFramebufferSizeCallback( g_window, glfw_framebuffer_size_callback );
   glfwMakeContextCurrent( g_window );
 
-  glfwWindowHint( GLFW_SAMPLES, 4 );
 
   /* start GLEW extension handler */
   glewExperimental = GL_TRUE;


### PR DESCRIPTION
Hi!, I've modified 'gl_utils.c' in the example named '02_shaders', so glfwWindowHint is now called BEFORE the window is created. 
In the original code, it was called AFTER the window was created with glfwCreateWindow, and multisampling was not working.
