### PR TITLE
Add Apple Silicon support

### DIFF
--- a/00_hello_triangle/Makefile.osxARM
+++ b/00_hello_triangle/Makefile.osxARM
@@ -1,0 +1,12 @@
+BIN = hellot
+CC = clang
+FLAGS = -std=c99 -DAPPLE -Wall -pedantic -Wextra
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.c
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+
+

--- a/00_hello_triangle_gl2.1/Makefile.osxARM
+++ b/00_hello_triangle_gl2.1/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = hellot
+CC = clang
+FLAGS = -std=c99 -DAPPLE -Wall -pedantic -mmacosx-version-min=10.5 -fmessage-length=0 -UGLFW_CDECL -fprofile-arcs -ftest-coverage
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.c
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/01_extended_init/Makefile.osxARM
+++ b/01_extended_init/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = extinit
+CC = clang
+FLAGS = -std=c99 -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.c
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/02_shaders/Makefile.osxARM
+++ b/02_shaders/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = shaders
+CC = clang
+FLAGS = -std=c99 -DAPPLE -Wall -pedantic -mmacosx-version-min=10.5 -fmessage-length=0 -UGLFW_CDECL -fprofile-arcs -ftest-coverage
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.c gl_utils.c
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/03_vertex_buffer_objects/Makefile.osxARM
+++ b/03_vertex_buffer_objects/Makefile.osxARM
@@ -1,0 +1,10 @@
+BIN = vbuffs
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp gl_utils.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}

--- a/04_mats_and_vecs/Makefile.osxARM
+++ b/04_mats_and_vecs/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = matsvecs
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp gl_utils.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/05_virtual_camera/Makefile.osxARM
+++ b/05_virtual_camera/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = vcam
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp gl_utils.cpp maths_funcs.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/06_vcam_with_quaternion/Makefile.osxARM
+++ b/06_vcam_with_quaternion/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = quats
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp gl_utils.cpp maths_funcs.cpp obj_parser.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/07_ray_picking/Makefile.osxARM
+++ b/07_ray_picking/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = raypick
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp gl_utils.cpp maths_funcs.cpp obj_parser.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/08_phong/Makefile.osxARM
+++ b/08_phong/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = phong
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp gl_utils.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/09_texture_mapping/Makefile.osxARM
+++ b/09_texture_mapping/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = texmap
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp gl_utils.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/10_screen_capture/Makefile.osxARM
+++ b/10_screen_capture/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = scrcap
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp gl_utils.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/11_video_capture/Makefile.osxARM
+++ b/11_video_capture/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = vidcap
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp gl_utils.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/12_debugging_shaders/Makefile.osxARM
+++ b/12_debugging_shaders/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = debugshdrs
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp gl_utils.cpp obj_parser.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/13_mesh_import/Makefile.osxARM
+++ b/13_mesh_import/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = meshimp
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic -std=c++11
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib -lassimp
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp gl_utils.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/14_multi_tex/Makefile.osxARM
+++ b/14_multi_tex/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = multitex
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp gl_utils.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/15_phongtextures/Makefile.osxARM
+++ b/15_phongtextures/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = phongtex
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic -std=c++11
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib -lassimp
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp gl_utils.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/16_frag_reject/Makefile.osxARM
+++ b/16_frag_reject/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = fragrej
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp gl_utils.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/17_alpha_blending/Makefile.osxARM
+++ b/17_alpha_blending/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = alphablend
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp gl_utils.cpp 
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/18_spotlights/Makefile.osxARM
+++ b/18_spotlights/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = spotlights
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp gl_utils.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/19_fog/Makefile.osxARM
+++ b/19_fog/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = fog
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic -std=c++11
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib -lassimp
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp gl_utils.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/20_normal_mapping/Makefile.osxARM
+++ b/20_normal_mapping/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = nmap
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib -lassimp -std=c++11
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp gl_utils.cpp 
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/21_cube_mapping/Makefile.osxARM
+++ b/21_cube_mapping/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = cubemap
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic -std=c++11
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib -lassimp
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp gl_utils.cpp  obj_parser.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/22_geom_shaders/Makefile.osxARM
+++ b/22_geom_shaders/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = geomsh
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp gl_utils.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/23_tessellation_shaders/Makefile.osxARM
+++ b/23_tessellation_shaders/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = tess
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp gl_utils.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/24_gui_panels/Makefile.osxARM
+++ b/24_gui_panels/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = overlays
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp 
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/25_sprite_sheets/Makefile.osxARM
+++ b/25_sprite_sheets/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = sprites
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic -arch arm64
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp 
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/26_bitmap_fonts/Makefile.osxARM
+++ b/26_bitmap_fonts/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = fonts
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp 
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/27_font_atlas/Makefile.osxARM
+++ b/27_font_atlas/Makefile.osxARM
@@ -1,0 +1,14 @@
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic -arch arm64
+INC = -I/sw/include -I/opt/homebrew/include -I/opt/homebrew/include/freetype2/
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp 
+
+all: generator viewer
+
+generator:
+	${CC} ${FLAGS} -o generate generator_main.cpp  ${INC} -L/opt/homebrew/lib -lfreetype
+
+viewer:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o view viewer_main.cpp maths_funcs.cpp  ${INC} ${LIBS}

--- a/28_uniform_buffer_object/Makefile.osxARM
+++ b/28_uniform_buffer_object/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = cubemap
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic -std=c++11
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib -lassimp
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp gl_utils.cpp  obj_parser.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/29_particle_systems/Makefile.osxARM
+++ b/29_particle_systems/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = particles
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp gl_utils.cpp 
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/30_skinning_part_one/Makefile.osxARM
+++ b/30_skinning_part_one/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = skin
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic -std=c++11
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib -lassimp
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp gl_utils.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LOC_LIB} ${LIBS}
+

--- a/31_skinning_part_two/Makefile.osxARM
+++ b/31_skinning_part_two/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = skin
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic -std=c++11
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib -lassimp
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp gl_utils.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LOC_LIB} ${LIBS}
+

--- a/32_skinning_part_three/Makefile.osxARM
+++ b/32_skinning_part_three/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = skin
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic -std=c++11
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib -lassimp
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp gl_utils.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LOC_LIB} ${LIBS}
+

--- a/34_framebuffer_switch/Makefile.osxARM
+++ b/34_framebuffer_switch/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = fbuffer
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp gl_utils.cpp obj_parser.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+	

--- a/35_image_kernel/Makefile.osxARM
+++ b/35_image_kernel/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = kernel
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp gl_utils.cpp obj_parser.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/36_colour_picking/Makefile.osxARM
+++ b/36_colour_picking/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = pick
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp gl_utils.cpp obj_parser.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/37_deferred_shading/Makefile.osxARM
+++ b/37_deferred_shading/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = deferred
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp gl_utils.cpp obj_parser.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/38_texture_shadows/Makefile.osxARM
+++ b/38_texture_shadows/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = shads
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp gl_utils.cpp obj_parser.cpp maths_funcs.cpp
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/39_texture_mapping_srgb/Makefile.osxARM
+++ b/39_texture_mapping_srgb/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN = texmap
+CC = clang++
+FLAGS = -DAPPLE -Wall -pedantic
+INC = -I/sw/include -I/opt/homebrew/include
+LIBS = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC = main.cpp maths_funcs.cpp gl_utils.cpp 
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/41_shader_hot_reload/Makefile.osxARM
+++ b/41_shader_hot_reload/Makefile.osxARM
@@ -1,0 +1,11 @@
+BIN        = hotreload
+CC         = clang
+FLAGS      = -DAPPLE -Wall -pedantic -mmacosx-version-min=10.5 -fmessage-length=0 -UGLFW_CDECL -fprofile-arcs -ftest-coverage
+INC        = -I/sw/include -I/opt/homebrew/include
+LIBS       = -lGLEW -lglfw -L/opt/homebrew/lib
+FRAMEWORKS = -framework Cocoa -framework OpenGL -framework IOKit
+SRC        = main.c
+
+all:
+	${CC} ${FLAGS} ${FRAMEWORKS} -o ${BIN} ${SRC} ${INC} ${LIBS}
+

--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ E.g. for Ubuntu:
 * You will probably wish to install libraries via [Homebrew](https://brew.sh/), similarly to Linux, above.
   `brew install glew glfw assimp freetype`
 
-* Open a terminal and `cd` to the demo of choice:
-  `make -f Makefile.osx`
+* Open a terminal and `cd` to the demo of choice.
+  * For Intel Macs, run `make -f Makefile.osx`
+  * For Apple Silicon Macs, run `make -f Makefile.osxARM`
 
 * To build all the demos you can run `./build_all_linux_osx.sh` from the main directory.
 

--- a/build_all_linux_osx.sh
+++ b/build_all_linux_osx.sh
@@ -59,7 +59,11 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
 		MAKEFILE=Makefile.linux64
 	fi
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-	MAKEFILE=Makefile.osx
+  if [ ${ARCH} == 'arm64' ]; then
+		MAKEFILE=Makefile.osxARM
+	else
+	  MAKEFILE=Makefile.osx
+  fi
 fi
 
 ## call make inside each folder


### PR DESCRIPTION
First of all, thanks for open sourcing these informative code samples! 🙂🙂

This PR adds support for building on Apple Silicon machines (without introducing additional tools).
I created new makefiles for the ARM64 architecture, separate from the Intel ones, so it won't affect building on Intel machines.

P.S. Some Makefile.osx files are missing ${INC} variables in the "all" target. Not sure if this would cause any issues, just an FYI.